### PR TITLE
Update acquisition stats

### DIFF
--- a/content/site-content.json
+++ b/content/site-content.json
@@ -31,9 +31,9 @@
 
   "stats": {
     "items": [
-      { "value": 190, "prefix": "$", "suffix": "M+", "label": "GAV Acquired" },
-      { "value": 44, "suffix": "", "label": "Buildings Acquired" },
-      { "value": 600, "suffix": "+", "label": "Units Acquired" },
+      { "value": 200, "prefix": "$", "suffix": "M+", "label": "GAV Acquired" },
+      { "value": 47, "suffix": "", "label": "Buildings Acquired" },
+      { "value": 625, "suffix": "+", "label": "Units Acquired" },
       { "value": 250, "suffix": "+", "label": "Units in Development" }
     ],
     "footnote": "*As of Q2 2026"


### PR DESCRIPTION
Updates the three acquisition figures in the Track Record band.

| Stat | Before | After |
|---|---|---|
| GAV Acquired | \$190M+ | **\$200M+** |
| Buildings Acquired | 44 | **47** |
| Units Acquired | 600+ | **625+** |

"Units in Development" (250+) is unchanged, as is the display order and the "*As of Q2 2026" footnote.

Content-only change to `content/site-content.json`; no component edits. `npm run build` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)