### PR TITLE
Remove Shadi Kashani placeholder card

### DIFF
--- a/content/site-content.json
+++ b/content/site-content.json
@@ -106,13 +106,6 @@
         "division": "Property Managers",
         "bio": "John is a Partner at LWK, where he spearheads the firm's asset management capabilities. Previously, John served as Head of Brokerage at Dover Management Corporation, where he led the firm's brokerage and assisted with the asset management of 1,500 units. Prior to his role at Dover, he founded and scaled Alden Pacific Investments to a 12-person team that was successfully merged with a competitor in 2022. Before Alden Pacific Investments, John opened and scaled offices for a firm focused on sub-institutional multifamily investments throughout LA County, and he has advised on the sale and disposition of over $300 million in assets throughout his career. Before rising to executive leadership, John held various consultative sales roles in financial and healthcare software verticals. He holds a BA from the University of Minnesota and an MBA from the University of California Los Angeles.",
         "email": "jalden@lwkpartners.com"
-      },
-      {
-        "name": "Shadi Kashani",
-        "title": "Senior Portfolio Manager",
-        "division": "Property Managers",
-        "bio": "Bio coming soon.",
-        "email": "shadi@lwrep.co"
       }
     ]
   },

--- a/src/components/sections/Team.tsx
+++ b/src/components/sections/Team.tsx
@@ -54,7 +54,11 @@ export default function Team() {
               {teamSection.divisions.propertyManagers}
             </h3>
           </FadeInUp>
-          <StaggerChildren className="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
+          <StaggerChildren
+            className={`grid gap-6 mx-auto ${
+              propertyManagers.length === 1 ? 'max-w-sm' : 'md:grid-cols-2 max-w-3xl'
+            }`}
+          >
             {propertyManagers.map((member) => (
               <TeamCard key={member.name} member={member} />
             ))}


### PR DESCRIPTION
Removes the Shadi Kashani team card, which was live on production with a `"Bio coming soon."` placeholder.

Also centers the Property Managers card when the division has a single member — otherwise John Alden's card renders left-aligned in an empty 2-column grid. Reverts to the 2-column layout automatically if a second property manager is added.

Verified locally: `npm run build` passes, `npm run lint` clean (4 pre-existing `<img>` warnings, untouched), and the rendered card measures 0px offset from center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)