### PR TITLE
Update units acquired to 650+

### DIFF
--- a/content/site-content.json
+++ b/content/site-content.json
@@ -33,7 +33,7 @@
     "items": [
       { "value": 200, "prefix": "$", "suffix": "M+", "label": "GAV Acquired" },
       { "value": 47, "suffix": "", "label": "Buildings Acquired" },
-      { "value": 625, "suffix": "+", "label": "Units Acquired" },
+      { "value": 650, "suffix": "+", "label": "Units Acquired" },
       { "value": 250, "suffix": "+", "label": "Units in Development" }
     ],
     "footnote": "*As of Q2 2026"


### PR DESCRIPTION
Bumps the Units Acquired stat from 625+ to 650+.

Other stats unchanged: $200M+ GAV Acquired, 47 Buildings Acquired, 250+ Units in Development. Footnote still reads "*As of Q2 2026".

🤖 Generated with [Claude Code](https://claude.com/claude-code)