### PR TITLE
Add LinkedIn link for John Alden

### DIFF
--- a/content/site-content.json
+++ b/content/site-content.json
@@ -105,7 +105,8 @@
         "title": "Partner, Head of Asset Management",
         "division": "Property Managers",
         "bio": "John is a Partner at LWK, where he spearheads the firm's asset management capabilities. Previously, John served as Head of Brokerage at Dover Management Corporation, where he led the firm's brokerage and assisted with the asset management of 1,500 units. Prior to his role at Dover, he founded and scaled Alden Pacific Investments to a 12-person team that was successfully merged with a competitor in 2022. Before Alden Pacific Investments, John opened and scaled offices for a firm focused on sub-institutional multifamily investments throughout LA County, and he has advised on the sale and disposition of over $300 million in assets throughout his career. Before rising to executive leadership, John held various consultative sales roles in financial and healthcare software verticals. He holds a BA from the University of Minnesota and an MBA from the University of California Los Angeles.",
-        "email": "jalden@lwkpartners.com"
+        "email": "jalden@lwkpartners.com",
+        "linkedin": "https://www.linkedin.com/in/johnalden10/"
       }
     ]
   },


### PR DESCRIPTION
Adds `linkedin` to John Alden's team entry, so his LinkedIn icon becomes an active link instead of the inert placeholder icon `TeamCard` renders when the field is absent.

All five team members now have a LinkedIn URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)