### PR TITLE
Fold John Alden into Asset Management

### DIFF
--- a/content/site-content.json
+++ b/content/site-content.json
@@ -64,8 +64,7 @@
     "title": "Leadership",
     "divisions": {
       "acquisitions": "Acquisitions",
-      "assetManagement": "Asset Management",
-      "propertyManagers": "Property Managers"
+      "assetManagement": "Asset Management"
     },
     "members": [
       {
@@ -103,7 +102,7 @@
       {
         "name": "John Alden",
         "title": "Partner, Head of Asset Management",
-        "division": "Property Managers",
+        "division": "Asset Management",
         "bio": "John is a Partner at LWK, where he spearheads the firm's asset management capabilities. Previously, John served as Head of Brokerage at Dover Management Corporation, where he led the firm's brokerage and assisted with the asset management of 1,500 units. Prior to his role at Dover, he founded and scaled Alden Pacific Investments to a 12-person team that was successfully merged with a competitor in 2022. Before Alden Pacific Investments, John opened and scaled offices for a firm focused on sub-institutional multifamily investments throughout LA County, and he has advised on the sale and disposition of over $300 million in assets throughout his career. Before rising to executive leadership, John held various consultative sales roles in financial and healthcare software verticals. He holds a BA from the University of Minnesota and an MBA from the University of California Los Angeles.",
         "email": "jalden@lwkpartners.com",
         "linkedin": "https://www.linkedin.com/in/johnalden10/"

--- a/src/components/sections/Team.tsx
+++ b/src/components/sections/Team.tsx
@@ -10,7 +10,6 @@ import FadeInUp from '../animations/FadeInUp';
 export default function Team() {
   const acquisitions = teamMembers.filter((m) => m.division === 'Acquisitions');
   const assetManagement = teamMembers.filter((m) => m.division === 'Asset Management');
-  const propertyManagers = teamMembers.filter((m) => m.division === 'Property Managers');
 
   return (
     <section id="team" className="section-padding bg-gray-50">
@@ -34,7 +33,7 @@ export default function Team() {
         </div>
 
         {/* Asset Management */}
-        <div className="mb-14">
+        <div>
           <FadeInUp>
             <h3 className="text-center text-xs font-semibold tracking-[0.15em] text-gray-600 uppercase mb-8">
               {teamSection.divisions.assetManagement}
@@ -42,24 +41,6 @@ export default function Team() {
           </FadeInUp>
           <StaggerChildren className="grid md:grid-cols-2 gap-6 max-w-3xl mx-auto">
             {assetManagement.map((member) => (
-              <TeamCard key={member.name} member={member} />
-            ))}
-          </StaggerChildren>
-        </div>
-
-        {/* Property Managers */}
-        <div>
-          <FadeInUp>
-            <h3 className="text-center text-xs font-semibold tracking-[0.15em] text-gray-600 uppercase mb-8">
-              {teamSection.divisions.propertyManagers}
-            </h3>
-          </FadeInUp>
-          <StaggerChildren
-            className={`grid gap-6 mx-auto ${
-              propertyManagers.length === 1 ? 'max-w-sm' : 'md:grid-cols-2 max-w-3xl'
-            }`}
-          >
-            {propertyManagers.map((member) => (
               <TeamCard key={member.name} member={member} />
             ))}
           </StaggerChildren>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ export interface Stat {
 export interface TeamMember {
   name: string;
   title: string;
-  division: 'Acquisitions' | 'Asset Management' | 'Property Managers';
+  division: 'Acquisitions' | 'Asset Management';
   bio: string;
   email?: string;
   linkedin?: string;


### PR DESCRIPTION
Removes the "Property Managers" heading and moves John Alden's tile into the Asset Management group, after Matt Osborn — matching his title, "Partner, Head of Asset Management".

Cleanup of what the move orphaned:
- `propertyManagers` division label in `site-content.json`
- `propertyManagers` filter and section block in `Team.tsx`
- `'Property Managers'` variant in the `TeamMember['division']` union, so a member can't be assigned a division that renders nowhere
- the single-member centering rule, which existed only for that block

`npm run build` passes; `npm run lint` clean (4 pre-existing `<img>` warnings, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)